### PR TITLE
added apostrophe (the call's structure)

### DIFF
--- a/ai.md
+++ b/ai.md
@@ -90,7 +90,7 @@ One of the difficulties in decoding an unknown vocalized language is determining
 
 ```
 A linearly reassigned spectrogram of a single dolphin whistle with two echolocation
-clicks, showing the calls fine structure. Resolving which part of this signal is
+clicks, showing the call's fine structure. Resolving which part of this signal is
 meaningful is an unsolved problem.
 ```
 


### PR DESCRIPTION
Fixed a tiny typo, apostrophy was missing from "the call[']s fine structure".